### PR TITLE
Ensuring compatibility with boto3-1.9.42 on Lambda

### DIFF
--- a/lambda_function.py
+++ b/lambda_function.py
@@ -38,7 +38,10 @@ def handler(event, context):
                     'AttributeType': 'S'
                 }
             ],
-            BillingMode='PAY_PER_REQUEST',
+            ProvisionedThroughput={
+                'ReadCapacityUnits': 2,
+                'WriteCapacityUnits': 2,
+            }
         )
         waiter = dynamodb.get_waiter('table_exists')
         waiter.wait(


### PR DESCRIPTION
Unfortunately the boto3 version on Lambda does not support BillingMode yet. Since the function consumes a very predictable capacity, a value of 2 should be sufficient.